### PR TITLE
Expose `unroll` parameter in `make_ring` for GPU acceleration

### DIFF
--- a/src/ring/ml/ringnet.py
+++ b/src/ring/ml/ringnet.py
@@ -88,6 +88,7 @@ def make_ring(
     link_output_transform: Optional[Callable] = None,
     layernorm: bool = True,
     layernorm_trainable: bool = True,
+    unroll: int = 1,
 ) -> SimpleNamespace:
 
     if link_output_normalize:
@@ -134,6 +135,7 @@ def make_ring(
             ),
             X,
             state,
+            unroll=unroll,
         )
         hk.set_state("inner_cell_state", state)
         return y

--- a/src/ring/ml/rnno_v1.py
+++ b/src/ring/ml/rnno_v1.py
@@ -16,6 +16,7 @@ def rnno_v1_forward_factory(
     act_fn_rnn=jax.nn.elu,
     lam: Optional[tuple[int]] = None,
     celltype: str = "gru",
+    unroll: int = 1,
 ):
     # unused
     del lam
@@ -37,7 +38,7 @@ def rnno_v1_forward_factory(
 
         for i, n_units in enumerate(rnn_layers):
             state = hk.get_state(f"rnn_{i}", shape=[n_units * _factor], init=jnp.zeros)
-            X, state = hk.dynamic_unroll(_cell(n_units), X, state)
+            X, state = hk.dynamic_unroll(_cell(n_units), X, state, unroll=unroll)
             hk.set_state(f"rnn_{i}", state)
 
             if layernorm:


### PR DESCRIPTION
## Summary

- Adds an `unroll` parameter (default `1`) to both `make_ring()` and `rnno_v1_forward_factory()`, passed through to `hk.dynamic_unroll`
- On GPU, `lax.scan` launches a separate kernel per iteration. Unrolling lets XLA fuse multiple iterations into one kernel, reducing launch overhead
- Fully backward-compatible: default `unroll=1` preserves existing behavior

## Benchmark (RING, RTX 4080)

T=1000, lam=[-1,0,1], H=400, D=200:

| unroll | forward | fwd speedup | backward | bwd speedup |
|--------|---------|-------------|----------|-------------|
| 1      | 46.4ms  | 1.00x       | 482.5ms  | 1.00x       |
| 5      | 34.4ms  | 1.35x       | 120.2ms  | **4.01x**   |
| 10     | 32.7ms  | 1.42x       | 119.7ms  | **4.03x**   |
| 20     | 32.4ms  | 1.43x       | 114.0ms  | **4.23x**   |
| 50     | 31.6ms  | 1.47x       | 118.0ms  | 4.09x       |

Sweet spot is `unroll=20`: **~1.4x forward, ~4.2x backward** speedup with reasonable one-time compile overhead (~20s vs ~4s baseline).

## Usage

```python
# RING
model = RING(lam=lam, unroll=20)

# RNNO
model = RING(forward_factory=rnno_v1_forward_factory, lam=lam, unroll=20)
```